### PR TITLE
Fix log viewport help text and add wrap toggle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0
-	github.com/rdalbuquerque/viewsearch v0.2.0
+	github.com/rdalbuquerque/viewsearch v0.3.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,10 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0
-	github.com/muesli/reflow v0.3.0
 	github.com/rdalbuquerque/viewsearch v0.1.0
 )
+
+replace github.com/rdalbuquerque/viewsearch => ../viewsearch
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0
-	github.com/rdalbuquerque/viewsearch v0.1.0
+	github.com/rdalbuquerque/viewsearch v0.2.0
 )
-
-replace github.com/rdalbuquerque/viewsearch => ../viewsearch
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rdalbuquerque/viewsearch v0.2.0 h1:vXq27P6+kRmX4XoXZA4cMtgW7Mcztj38lRxSlJtvfX8=
+github.com/rdalbuquerque/viewsearch v0.2.0/go.mod h1:jj4Gs0mq6SN3lqo07OVDwlu6dN1Dp7XiZ+1MpNwa8/w=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rdalbuquerque/viewsearch v0.2.0 h1:vXq27P6+kRmX4XoXZA4cMtgW7Mcztj38lRxSlJtvfX8=
-github.com/rdalbuquerque/viewsearch v0.2.0/go.mod h1:jj4Gs0mq6SN3lqo07OVDwlu6dN1Dp7XiZ+1MpNwa8/w=
+github.com/rdalbuquerque/viewsearch v0.3.0 h1:/YqyEN3/0kdhlGMMLXGtn1lPrnqpFH7FKM8tHXJ97WE=
+github.com/rdalbuquerque/viewsearch v0.3.0/go.mod h1:jj4Gs0mq6SN3lqo07OVDwlu6dN1Dp7XiZ+1MpNwa8/w=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=

--- a/go.sum
+++ b/go.sum
@@ -73,7 +73,6 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.20 h1:WcT52H91ZUAwy8+HUkdM3THM6gXqXuLJi9O3rjcQQaQ=
 github.com/mattn/go-runewidth v0.0.20/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
@@ -82,16 +81,10 @@ github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0 h1:mmJCWLe63Qvybx
 github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0/go.mod h1:mDunUZ1IUJdJIRHvFb+LPBUtxe3AYB5MI6BMXNg8194=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
-github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
-github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rdalbuquerque/viewsearch v0.1.0 h1:qM+VNdleowrWl2N7YSvqXd1jMvVchLYuTdCIg3QrytU=
-github.com/rdalbuquerque/viewsearch v0.1.0/go.mod h1:jj4Gs0mq6SN3lqo07OVDwlu6dN1Dp7XiZ+1MpNwa8/w=
-github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=

--- a/pkg/pages/pages.go
+++ b/pkg/pages/pages.go
@@ -37,8 +37,13 @@ func (s *Stack) Peek() PageInterface {
 	return (*s)[len(*s)-1]
 }
 
+const SectionSpacer = "  "
+
 func attachView(view string, sectionView string) string {
-	return lipgloss.JoinHorizontal(lipgloss.Left, view, "  ", sectionView)
+	if view == "" {
+		return sectionView
+	}
+	return lipgloss.JoinHorizontal(lipgloss.Left, view, SectionSpacer, sectionView)
 }
 
 type helpKeys struct{}

--- a/pkg/pages/pipelinerun.go
+++ b/pkg/pages/pipelinerun.go
@@ -77,6 +77,8 @@ func NewPipelineRunPage(ctx context.Context, buildclient azdo.BuildClientInterfa
 	pipelineRunPage.AddSection(logvpsec)
 	pipelineRunPage.sections[sections.LogViewport].Blur()
 	pipelineRunPage.sections[sections.PipelineTasks].Focus()
+	// Set dimensions using page-level logic which accounts for spacer width
+	pipelineRunPage.SetDimensions(0, styles.Height)
 	return pipelineRunPage
 }
 
@@ -87,7 +89,7 @@ func (p *PipelineRunPage) GetPageName() PageName {
 func (p *PipelineRunPage) SetDimensions(width, height int) {
 	if width == 0 {
 		p.sections[sections.PipelineTasks].SetDimensions(styles.DefaultSectionWidth, height)
-		p.sections[sections.LogViewport].SetDimensions(styles.Width-styles.DefaultSectionWidth, height)
+		p.sections[sections.LogViewport].SetDimensions(styles.Width-styles.DefaultSectionWidth-len(SectionSpacer), height)
 		return
 	}
 	for _, section := range p.orderedSections {
@@ -157,7 +159,7 @@ func (p *PipelineRunPage) restoreSectionDimensions() {
 		p.sections[sections.PipelineTasks].SetDimensions(styles.DefaultSectionWidth, styles.Height)
 		p.sections[sections.LogViewport].Show()
 	} else {
-		p.sections[sections.LogViewport].SetDimensions(styles.Width-styles.DefaultSectionWidth, styles.Height)
+		p.sections[sections.LogViewport].SetDimensions(styles.Width-styles.DefaultSectionWidth-len(SectionSpacer), styles.Height)
 		p.sections[sections.PipelineTasks].Show()
 	}
 }
@@ -169,7 +171,8 @@ func (p *PipelineRunPage) View() string {
 			view = attachView(view, p.sections[section].View())
 		}
 	}
-	viewWithHelp := lipgloss.JoinVertical(lipgloss.Top, view, p.shorthelp)
+	clampedHelp := lipgloss.NewStyle().MaxWidth(styles.Width).Render(p.shorthelp)
+	viewWithHelp := lipgloss.JoinVertical(lipgloss.Top, view, clampedHelp)
 	return viewWithHelp
 }
 

--- a/pkg/sections/logviewport.go
+++ b/pkg/sections/logviewport.go
@@ -20,7 +20,6 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/google/uuid"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/build"
-	"github.com/muesli/reflow/wordwrap"
 )
 
 type LogViewportSection struct {
@@ -115,7 +114,7 @@ func (p *LogViewportSection) Blur() {
 }
 
 func (p *LogViewportSection) View() string {
-	helpPlacement := lipgloss.NewStyle().PaddingLeft(p.logviewport.Viewport.Width() - len(p.StyledHelpText) + 18)
+	helpPlacement := lipgloss.NewStyle().PaddingLeft(p.logviewport.Viewport.Width() - lipgloss.Width(p.StyledHelpText))
 	logsAndHelp := lipgloss.JoinVertical(lipgloss.Top, p.logviewport.View(), helpPlacement.Render(p.StyledHelpText))
 	if p.focused {
 		return styles.ActiveStyle.Render(logsAndHelp)
@@ -126,8 +125,7 @@ func (p *LogViewportSection) View() string {
 func (p *LogViewportSection) Update(msg tea.Msg) (Section, tea.Cmd) {
 	switch msg := msg.(type) {
 	case teamsg.ToggleMaximizeMsg:
-		wrappedContent := wordwrap.String(p.buildLogs[p.currentStep], p.logviewport.Viewport.Width())
-		p.logviewport.SetContent(wrappedContent)
+		p.logviewport.SetContent(p.buildLogs[p.currentStep])
 		return p, nil
 	case teamsg.PipelineRunIdMsg:
 		if p.currentRunId == msg.RunId {
@@ -162,22 +160,21 @@ func (p *LogViewportSection) Update(msg tea.Msg) (Section, tea.Cmd) {
 		currentLog += formatLine(msg.NewContent, lineNum)
 		p.buildLogs[msg.StepRecordId] = currentLog
 		if p.currentStep == msg.StepRecordId {
-			p.logviewport.SetContent(wordwrap.String(currentLog, p.logviewport.Viewport.Width()))
+			p.logviewport.SetContent(currentLog)
 		}
 		if p.followRun {
 			p.currentStep = msg.StepRecordId
-			p.logviewport.SetContent(wordwrap.String(currentLog, p.logviewport.Viewport.Width()))
+			p.logviewport.SetContent(currentLog)
 			p.logviewport.GotoBottom()
 		}
 		return p, waitForLogs(p.logsChan)
 	case teamsg.RecordSelectedMsg:
-		wrappedContent := wordwrap.String(p.buildLogs[msg.RecordId], p.logviewport.Viewport.Width())
-		p.logviewport.SetContent(wrappedContent)
+		p.logviewport.SetContent(p.buildLogs[msg.RecordId])
 		p.logviewport.GotoBottom()
 		p.currentStep = msg.RecordId
 		return p, nil
 	case tea.KeyPressMsg:
-		if msg.String() == "f" {
+		if msg.String() == "f" && !p.logviewport.SearchActive() {
 			p.followRun = !p.followRun
 			return p, nil
 		}

--- a/pkg/sections/logviewport.go
+++ b/pkg/sections/logviewport.go
@@ -28,7 +28,6 @@ type LogViewportSection struct {
 	hidden            bool
 	focused           bool
 	ctx               context.Context
-	StyledHelpText    string
 	followRun         bool
 	currentStep       uuid.UUID
 	currentRunId      int
@@ -62,8 +61,6 @@ func NewLogViewport(ctx context.Context, secid SectionName, azdoconfig azdo.Conf
 	vp := viewsearch.New()
 	vp.SetShowHelp(false)
 
-	styledHelpText := styles.ShortHelpStyle.Render("/ find • alt+m maximize")
-
 	signalrClient := azdosignalr.NewSignalR(azdoconfig.OrgName, azdoconfig.AccoundId, azdoconfig.ProjectId, azdoconfig.AuthHeader)
 
 	connClosedChan := make(chan bool)
@@ -79,7 +76,6 @@ func NewLogViewport(ctx context.Context, secid SectionName, azdoconfig azdo.Conf
 		sectionIdentifier: secid,
 		azdoConfig:        azdoconfig,
 		signalrClient:     signalrClient,
-		StyledHelpText:    styledHelpText,
 		buildclient:       buildclient,
 	}
 }
@@ -113,9 +109,21 @@ func (p *LogViewportSection) Blur() {
 	p.focused = false
 }
 
+func (p *LogViewportSection) helpText() string {
+	wrapIndicator := "off"
+	if p.logviewport.Viewport.SoftWrap {
+		wrapIndicator = "on"
+	}
+	return styles.ShortHelpStyle.Render("/ find • alt+m maximize • alt+w wrap:" + wrapIndicator)
+}
+
 func (p *LogViewportSection) View() string {
-	helpPlacement := lipgloss.NewStyle().PaddingLeft(p.logviewport.Viewport.Width() - lipgloss.Width(p.StyledHelpText))
-	logsAndHelp := lipgloss.JoinVertical(lipgloss.Top, p.logviewport.View(), helpPlacement.Render(p.StyledHelpText))
+	helpText := p.helpText()
+	vpWidth := p.logviewport.Viewport.Width()
+	helpWidth := lipgloss.Width(helpText)
+	padding := max(0, vpWidth-helpWidth)
+	renderedHelp := lipgloss.NewStyle().PaddingLeft(padding).MaxWidth(vpWidth).Render(helpText)
+	logsAndHelp := lipgloss.JoinVertical(lipgloss.Top, p.logviewport.View(), renderedHelp)
 	if p.focused {
 		return styles.ActiveStyle.Render(logsAndHelp)
 	}
@@ -174,6 +182,10 @@ func (p *LogViewportSection) Update(msg tea.Msg) (Section, tea.Cmd) {
 		p.currentStep = msg.RecordId
 		return p, nil
 	case tea.KeyPressMsg:
+		if msg.String() == "alt+w" {
+			p.logviewport.Viewport.SoftWrap = !p.logviewport.Viewport.SoftWrap
+			return p, nil
+		}
 		if msg.String() == "f" && !p.logviewport.SearchActive() {
 			p.followRun = !p.followRun
 			return p, nil

--- a/pkg/sections/logviewport_view_test.go
+++ b/pkg/sections/logviewport_view_test.go
@@ -21,10 +21,8 @@ import (
 func newTestLogViewport() *LogViewportSection {
 	vp := viewsearch.New()
 	vp.SetShowHelp(false)
-	styledHelpText := styles.ShortHelpStyle.Render("/ find • alt+m maximize")
 	return &LogViewportSection{
 		logviewport:       &vp,
-		StyledHelpText:    styledHelpText,
 		sectionIdentifier: LogViewport,
 	}
 }
@@ -63,7 +61,7 @@ func (h pageHelpKeys) ShortHelp() []key.Binding {
 // It simulates the real startup: styles.SetDimensions is called first (from
 // WindowSizeMsg), then the page constructor runs and calls page.SetDimensions.
 func TestHelpTextFullyVisibleBehavior(t *testing.T) {
-	helpText := "/ find • alt+m maximize"
+	helpText := "/ find • alt+m maximize • alt+w wrap:off"
 
 	for _, termWidth := range []int{80, 100, 120, 160, 200} {
 		t.Run(fmt.Sprintf("termWidth_%d", termWidth), func(t *testing.T) {
@@ -110,12 +108,16 @@ func TestHelpTextFullyVisibleBehavior(t *testing.T) {
 				}
 			}
 
-			if !strings.Contains(pageView, helpText) {
-				for i := len(helpText); i > 0; i-- {
-					if strings.Contains(pageView, helpText[:i]) {
-						t.Errorf("help text truncated, found %q (missing %q)",
-							helpText[:i], helpText[i:])
-						break
+			helpVisibleWidth := lipgloss.Width(helpText)
+			logViewportWidth := termWidth - styles.DefaultSectionWidth - len(testSpacer)
+			if logViewportWidth >= helpVisibleWidth {
+				if !strings.Contains(pageView, helpText) {
+					for i := len(helpText); i > 0; i-- {
+						if strings.Contains(pageView, helpText[:i]) {
+							t.Errorf("help text truncated, found %q (missing %q)",
+								helpText[:i], helpText[i:])
+							break
+						}
 					}
 				}
 			}
@@ -140,12 +142,14 @@ func TestHelpTextFullyVisibleBehavior(t *testing.T) {
 					pageWidth2, termWidth, pageWidth2-termWidth)
 			}
 
-			if !strings.Contains(pageView2, helpText) {
-				for i := len(helpText); i > 0; i-- {
-					if strings.Contains(pageView2, helpText[:i]) {
-						t.Errorf("[log focused] help text truncated, found %q (missing %q)",
-							helpText[:i], helpText[i:])
-						break
+			if logViewportWidth >= helpVisibleWidth {
+				if !strings.Contains(pageView2, helpText) {
+					for i := len(helpText); i > 0; i-- {
+						if strings.Contains(pageView2, helpText[:i]) {
+							t.Errorf("[log focused] help text truncated, found %q (missing %q)",
+								helpText[:i], helpText[i:])
+							break
+						}
 					}
 				}
 			}
@@ -165,12 +169,14 @@ func TestHelpTextFullyVisibleBehavior(t *testing.T) {
 					fullPageWidth, termWidth, fullPageWidth-termWidth)
 			}
 
-			if !strings.Contains(fullPageView, helpText) {
-				for i := len(helpText); i > 0; i-- {
-					if strings.Contains(fullPageView, helpText[:i]) {
-						t.Errorf("[full page] help text truncated, found %q (missing %q)",
-							helpText[:i], helpText[i:])
-						break
+			if logViewportWidth >= helpVisibleWidth {
+				if !strings.Contains(fullPageView, helpText) {
+					for i := len(helpText); i > 0; i-- {
+						if strings.Contains(fullPageView, helpText[:i]) {
+							t.Errorf("[full page] help text truncated, found %q (missing %q)",
+								helpText[:i], helpText[i:])
+							break
+						}
 					}
 				}
 			}

--- a/pkg/sections/logviewport_view_test.go
+++ b/pkg/sections/logviewport_view_test.go
@@ -1,0 +1,179 @@
+package sections
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"azdoext/pkg/listitems"
+	"azdoext/pkg/styles"
+
+	"github.com/rdalbuquerque/viewsearch"
+
+	bubbleshelp "charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/list"
+	"charm.land/lipgloss/v2"
+)
+
+// newTestLogViewport creates a minimal LogViewportSection for view testing,
+// bypassing azdo dependencies that are only needed for Update/network calls.
+func newTestLogViewport() *LogViewportSection {
+	vp := viewsearch.New()
+	vp.SetShowHelp(false)
+	styledHelpText := styles.ShortHelpStyle.Render("/ find • alt+m maximize")
+	return &LogViewportSection{
+		logviewport:       &vp,
+		StyledHelpText:    styledHelpText,
+		sectionIdentifier: LogViewport,
+	}
+}
+
+// newTestPipelineTasks creates a minimal PipelineTasksSection for view testing.
+func newTestPipelineTasks() *PipelineTasksSection {
+	tasklist := list.New([]list.Item{}, listitems.PipelineRecordItemDelegate{}, 0, 0)
+	tasklist.SetShowTitle(false)
+	tasklist.SetShowStatusBar(false)
+	tasklist.SetShowHelp(false)
+	tasklist.SetShowPagination(false)
+	return &PipelineTasksSection{
+		tasklist:          tasklist,
+		sectionIdentifier: PipelineTasks,
+	}
+}
+
+const testSpacer = "  " // matches pages.SectionSpacer
+
+// pageHelpKeys matches the helpKeys in pages.go
+type pageHelpKeys struct{}
+
+func (h pageHelpKeys) FullHelp() [][]key.Binding { return nil }
+func (h pageHelpKeys) ShortHelp() []key.Binding {
+	return []key.Binding{
+		key.NewBinding(key.WithKeys("ctrl+h"), key.WithHelp("ctrl+h", "help page")),
+		key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "switch section")),
+		key.NewBinding(key.WithKeys("ctrl+r"), key.WithHelp("ctrl+r", "restart")),
+		key.NewBinding(key.WithKeys("ctrl+b"), key.WithHelp("ctrl+b", "previous page")),
+		key.NewBinding(key.WithKeys(""), key.WithHelp("↑/k ↓/j navigate and", "↵ select on all lists")),
+	}
+}
+
+// TestHelpTextFullyVisibleBehavior creates real section instances, calls
+// SetDimensions and View() exactly as the app does, then checks the output.
+// It simulates the real startup: styles.SetDimensions is called first (from
+// WindowSizeMsg), then the page constructor runs and calls page.SetDimensions.
+func TestHelpTextFullyVisibleBehavior(t *testing.T) {
+	helpText := "/ find • alt+m maximize"
+
+	for _, termWidth := range []int{80, 100, 120, 160, 200} {
+		t.Run(fmt.Sprintf("termWidth_%d", termWidth), func(t *testing.T) {
+			termHeight := 30
+
+			// Simulate WindowSizeMsg setting global dimensions BEFORE page creation
+			// (matches the real startup: WindowSizeMsg arrives before AzdoConfigMsg)
+			styles.SetDimensions(termWidth, termHeight-3)
+
+			tasks := newTestPipelineTasks()
+			tasks.Show()
+			tasks.Focus()
+			tasks.SetDimensions(styles.DefaultSectionWidth, termHeight-3)
+
+			logvp := newTestLogViewport()
+			logvp.Show()
+			logvp.Blur()
+			logvp.SetDimensions(styles.Width-styles.DefaultSectionWidth-len(testSpacer), termHeight-3)
+
+			tasksView := tasks.View()
+			logView := logvp.View()
+
+			// Reproduce attachView: first section has no spacer, second does
+			pageView := lipgloss.JoinHorizontal(lipgloss.Left, tasksView, testSpacer, logView)
+
+			tasksWidth := lipgloss.Width(tasksView)
+			logWidth := lipgloss.Width(logView)
+			pageWidth := lipgloss.Width(pageView)
+
+			t.Logf("tasksWidth=%d logWidth=%d spacer=%d total=%d termWidth=%d",
+				tasksWidth, logWidth, len(testSpacer), pageWidth, termWidth)
+
+			if pageWidth > termWidth {
+				t.Errorf("page width %d exceeds terminal width %d (overflow by %d)",
+					pageWidth, termWidth, pageWidth-termWidth)
+			}
+
+			// Check the help text line specifically
+			lines := strings.Split(logView, "\n")
+			for i, line := range lines {
+				if strings.Contains(line, "find") || strings.Contains(line, "maximize") {
+					w := lipgloss.Width(line)
+					t.Logf("help text line %d: width=%d content=%q", i, w, line)
+				}
+			}
+
+			if !strings.Contains(pageView, helpText) {
+				for i := len(helpText); i > 0; i-- {
+					if strings.Contains(pageView, helpText[:i]) {
+						t.Errorf("help text truncated, found %q (missing %q)",
+							helpText[:i], helpText[i:])
+						break
+					}
+				}
+			}
+
+			// Now test with log focused (ActiveStyle) instead
+			tasks.Blur()
+			logvp.Focus()
+
+			tasksView2 := tasks.View()
+			logView2 := logvp.View()
+			pageView2 := lipgloss.JoinHorizontal(lipgloss.Left, tasksView2, testSpacer, logView2)
+
+			tasksWidth2 := lipgloss.Width(tasksView2)
+			logWidth2 := lipgloss.Width(logView2)
+			pageWidth2 := lipgloss.Width(pageView2)
+
+			t.Logf("[log focused] tasksWidth=%d logWidth=%d total=%d",
+				tasksWidth2, logWidth2, pageWidth2)
+
+			if pageWidth2 > termWidth {
+				t.Errorf("[log focused] page width %d exceeds terminal width %d (overflow by %d)",
+					pageWidth2, termWidth, pageWidth2-termWidth)
+			}
+
+			if !strings.Contains(pageView2, helpText) {
+				for i := len(helpText); i > 0; i-- {
+					if strings.Contains(pageView2, helpText[:i]) {
+						t.Errorf("[log focused] help text truncated, found %q (missing %q)",
+							helpText[:i], helpText[i:])
+						break
+					}
+				}
+			}
+
+			// Now test with page-level shorthelp JoinVertical (as PipelineRunPage.View does)
+			shorthelp := bubbleshelp.New().View(pageHelpKeys{})
+			// Clamp shorthelp to terminal width, as PipelineRunPage.View() does
+			clampedHelp := lipgloss.NewStyle().MaxWidth(termWidth).Render(shorthelp)
+			t.Logf("shorthelp width=%d clampedHelp width=%d", lipgloss.Width(shorthelp), lipgloss.Width(clampedHelp))
+
+			fullPageView := lipgloss.JoinVertical(lipgloss.Top, pageView2, clampedHelp)
+			fullPageWidth := lipgloss.Width(fullPageView)
+			t.Logf("[full page with shorthelp] width=%d", fullPageWidth)
+
+			if fullPageWidth > termWidth {
+				t.Errorf("[full page] width %d exceeds terminal width %d (overflow by %d)",
+					fullPageWidth, termWidth, fullPageWidth-termWidth)
+			}
+
+			if !strings.Contains(fullPageView, helpText) {
+				for i := len(helpText); i > 0; i-- {
+					if strings.Contains(fullPageView, helpText[:i]) {
+						t.Errorf("[full page] help text truncated, found %q (missing %q)",
+							helpText[:i], helpText[i:])
+						break
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fix help text truncation in log viewport (was using byte length instead of display width, not accounting for spacer/shorthelp padding)
- Add `alt+w` keybinding to toggle soft wrap on/off with dynamic help indicator
- Add `Esc` key to fully exit search mode in viewsearch
- Add horizontal scroll-to-match during search navigation
- Disable word wrapping in favor of viewport v2 horizontal scrolling
- Upgrade viewsearch to v0.3.0

## Test plan
- [x] Help text displays fully at terminal widths >= 100
- [x] Help text gracefully truncates at narrow widths (80)
- [x] `alt+w` toggles wrap and help text updates
- [x] `Esc` exits search mode from both typing and navigation
- [x] Search navigation scrolls horizontally to match
- [x] Behavioral tests pass at multiple terminal widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)